### PR TITLE
Remove `pk:` prefix before searching

### DIFF
--- a/src/components/pages/landing/pk-search.tsx
+++ b/src/components/pages/landing/pk-search.tsx
@@ -64,7 +64,8 @@ export function PkSearch() {
 
   // Handle search functionality with error control
   const handleSearch = async () => {
-    const trimmedQuery = query.trim()
+    // Remove leading "pk:" and any following whitespace if present.
+    const trimmedQuery = query.replace(/^pk:\s*/i, '').trim()
 
     setError(null)
 


### PR DESCRIPTION
This PR removes the `pk:` prefix, if present.

Fixes #2