### PR TITLE
feat: Make PKARR relay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Find your piece of digital sovereignty
 ```bash
 npm run dev
 ```
+
+## PKARR relays
+
+By default, the app uses the relay list provided by the PKARR library. To use custom relays, set `NEXT_PUBLIC_PKARR_RELAYS` to a comma-separated list:
+
+```bash
+NEXT_PUBLIC_PKARR_RELAYS=https://relay1.example,https://relay2.example npm run dev
+```

--- a/src/providers/pkarr-provider.tsx
+++ b/src/providers/pkarr-provider.tsx
@@ -45,6 +45,15 @@ const PkarrContext = createContext<PkarrContextType | undefined>(undefined)
 // Helper functions
 const isServerSide = () => typeof window === 'undefined'
 
+const configuredRelays = (): string[] | null => {
+  const relays = process.env.NEXT_PUBLIC_PKARR_RELAYS
+    ?.split(',')
+    .map((relay) => relay.trim())
+    .filter(Boolean)
+
+  return relays?.length ? relays : null
+}
+
 const resetSingletonState = (): void => {
   singletonState.client = null
   singletonState.initializationFailed = false
@@ -76,7 +85,8 @@ const initializePkarrClient = async (): Promise<Client> => {
   // Start new initialization
   singletonState.initializationPromise = Promise.resolve().then(() => {
     try {
-      const client = new Client()
+      const relays = configuredRelays()
+      const client = relays ? new Client(relays) : new Client()
       singletonState.client = client
       return client
     } catch (error) {


### PR DESCRIPTION
This PR adds the ability to configure the app with any PKARR relay. This allows one to use the digger with testnet.

## What Changed

By default, the app uses the relay list provided by the PKARR library. To use custom relays, set `NEXT_PUBLIC_PKARR_RELAYS` to a comma-separated list in `.env` or with `npm run dev`:

```bash
NEXT_PUBLIC_PKARR_RELAYS=https://relay1.example,https://relay2.example npm run dev
```