### PR TITLE
feat: Added settings to change the resolve policy; pkarr relays; pkarr v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ By default, the app uses the relay list provided by the PKARR library. To use cu
 ```bash
 NEXT_PUBLIC_PKARR_RELAYS=https://relay1.example,https://relay2.example npm run dev
 ```
+
+The settings button in the site header can override this relay list for the current browser. Browser settings are stored in `localStorage`; resetting them restores `NEXT_PUBLIC_PKARR_RELAYS`, or the PKARR defaults when the environment variable is unset.
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,11 +31,6 @@ const nextConfig: NextConfig = {
 
     return config;
   },
-  
-  // Ensure proper handling of experimental features
-  experimental: {
-    esmExternals: 'loose',
-  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-hover-card": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
-        "@synonymdev/pkarr": "^0.1.4-rc.2",
+        "@synonymdev/pkarr": "^1.0.0",
         "assert": "^2.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1090,6 +1091,262 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.20.tgz",
+      "integrity": "sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.16",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.13",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.14",
+        "@radix-ui/react-presence": "1.1.8",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.16.tgz",
+      "integrity": "sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.14.tgz",
+      "integrity": "sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
@@ -1113,6 +1370,117 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.13.tgz",
+      "integrity": "sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1144,6 +1512,39 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1426,9 +1827,9 @@
       }
     },
     "node_modules/@synonymdev/pkarr": {
-      "version": "0.1.4-rc.2",
-      "resolved": "https://registry.npmjs.org/@synonymdev/pkarr/-/pkarr-0.1.4-rc.2.tgz",
-      "integrity": "sha512-oNFM6SE02hT/wOfCDDJKWN1r3rR81CnBN2w0bYmZiYlBQ9M7o8bNjA1ZaoLbbnhHV0gu7LZ4Cy4Hapvi/B6luQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@synonymdev/pkarr/-/pkarr-1.0.0.tgz",
+      "integrity": "sha512-whY0WKmFW4VCxui00M6YupOmcKviuNlm9blDWDh+qgSJVs/OL6eWca/13eNnO1coUmL/fLZf7ObdG/js2BNVBQ==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -2382,6 +2783,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -3414,6 +3827,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -4434,6 +4853,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -6522,6 +6950,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -8091,6 +8588,49 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "license": "MIT"
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-hover-card": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
-    "@synonymdev/pkarr": "^0.1.4-rc.2",
+    "@synonymdev/pkarr": "^1.0.0",
     "assert": "^2.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/pages/records/pk-resolver.tsx
+++ b/src/components/pages/records/pk-resolver.tsx
@@ -10,6 +10,7 @@ import { SkeletonRow } from "@/components/pages/records/row-skeleton"
 import { NoRecordsFound } from "@/components/pages/records/no-records-found"
 import { ClientError } from "@/components/client-error"
 import { usePkarr } from "@/providers/pkarr-provider"
+import { RESOLVE_POLICY_LABELS, type ResolvePolicyName } from "@/lib/resolve-policy"
 import { saveRecentKey } from "@/lib/utils"
 
 // Constants
@@ -22,6 +23,7 @@ type PkarrPacket = {
   records: DnsRecord[] | null
   lastUpdated: string | null
   compressedSize: number | null
+  resolvePolicy: ResolvePolicyName | null
 }
 
 export function PkResolver({ publicKey }: { publicKey: string }) {
@@ -29,48 +31,76 @@ export function PkResolver({ publicKey }: { publicKey: string }) {
     const router = useRouter()
 
     // Global pkarr client state
-    const { client, isLoading: clientLoading, error: clientError, retry } = usePkarr()
+    const { resolve, settings, isLoading: clientLoading, error: clientError, retry } = usePkarr()
 
     const [loading, setLoading] = useState(false)
     const [copied, setCopied] = useState(false)
+    const [resolutionError, setResolutionError] = useState<string | null>(null)
+    const [refreshCount, setRefreshCount] = useState(0)
     const [pkarrPacket, setPkarrPacket] = useState<PkarrPacket>({
         records: null,
         lastUpdated: null,
-        compressedSize: null
+        compressedSize: null,
+        resolvePolicy: null
     })
 
     useEffect(() => {
+        let cancelled = false;
+
         const fetchKeyData = async () => {
-            if (!publicKey || !client) return;
+            if (!publicKey || clientLoading || clientError) return;
 
             try {
                 setLoading(true);
-                const resolvedPacket = await client.resolve(publicKey);
+                setResolutionError(null);
+                const resolvePolicy = settings.resolvePolicy;
+                const resolvedPacket = await resolve(publicKey);
 
                 if (!resolvedPacket) {
+                    if (cancelled) return;
                     console.log("No packet found for key:", publicKey);
-                    setPkarrPacket({ records: null, lastUpdated: null, compressedSize: null });
+                    setPkarrPacket({ records: null, lastUpdated: null, compressedSize: null, resolvePolicy: null });
                     return;
                 }
 
-                // Save the key in local storage
-                saveRecentKey(publicKey)
+                try {
+                    if (cancelled) return;
 
-                setPkarrPacket({
-                    records: resolvedPacket.records.map(getDnsRecord),
-                    lastUpdated: new Date(resolvedPacket.timestampMs / 1000).toISOString(),
-                    compressedSize: resolvedPacket.compressedBytes().length
-                });
+                    // Save the key in local storage
+                    saveRecentKey(publicKey)
+                    setPkarrPacket({
+                        records: resolvedPacket.records.map(getDnsRecord),
+                        lastUpdated: new Date(resolvedPacket.timestampMs / 1000).toISOString(),
+                        compressedSize: resolvedPacket.compressedBytes().length,
+                        resolvePolicy
+                    });
+                } finally {
+                    resolvedPacket.free();
+                }
             } catch (err) {
+                if (cancelled) return;
                 console.error("Error fetching key data:", err);
-                setPkarrPacket({ records: null, lastUpdated: null, compressedSize: null });
+                setResolutionError(err instanceof Error ? err.message : "Failed to resolve this public key");
+                setPkarrPacket({ records: null, lastUpdated: null, compressedSize: null, resolvePolicy: null });
             } finally {
-                setLoading(false);
+                if (!cancelled) setLoading(false);
             }
         };
 
         fetchKeyData();
-    }, [publicKey, client])
+
+        return () => {
+            cancelled = true;
+        };
+    }, [publicKey, resolve, settings.resolvePolicy, clientLoading, clientError, refreshCount])
+
+    const retryResolution = () => {
+        if (clientError) {
+            retry()
+        } else {
+            setRefreshCount((count) => count + 1)
+        }
+    }
 
     const copyToClipboard = async () => {
         try {
@@ -113,8 +143,8 @@ export function PkResolver({ publicKey }: { publicKey: string }) {
             </div>
 
             {/* DNS Records Table, No Records Message, or Client Error */}
-            {clientError ? (
-                <ClientError error={clientError} onRetry={retry} />
+            {(clientError || resolutionError) ? (
+                <ClientError error={clientError || resolutionError || "Unknown error"} onRetry={retryResolution} />
             ) : (clientLoading || loading) || pkarrPacket.records ? (
                 <div className="mb-6">
                     <div className="rounded-lg overflow-hidden">
@@ -151,7 +181,17 @@ export function PkResolver({ publicKey }: { publicKey: string }) {
             {/* Key Info - Below table with margin */}
             {pkarrPacket.records && (
                 <div className="mt-10 pt-6 border-t border-gray-700/30">
-                    <div className="flex justify-end space-x-8 text-sm">
+                    <div className="flex flex-wrap justify-end gap-8 text-sm">
+                        <div className="flex flex-col">
+                            <div className="text-gray-400 mb-1 text-xs uppercase tracking-wider">Resolve Policy</div>
+                            <div>
+                                {pkarrPacket.resolvePolicy ? (
+                                    <span className="text-sm font-normal text-gray-400">
+                                        {RESOLVE_POLICY_LABELS[pkarrPacket.resolvePolicy]}
+                                    </span>
+                                ) : 'Unknown'}
+                            </div>
+                        </div>
                         <div className="flex flex-col">
                             <div className="text-gray-400 mb-1 text-xs uppercase tracking-wider">Last Updated</div>
                             <div className="text-white font-medium">

--- a/src/components/pkarr-settings-dialog.tsx
+++ b/src/components/pkarr-settings-dialog.tsx
@@ -1,0 +1,183 @@
+"use client"
+
+import { useState } from "react"
+import { Cog, RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  DEFAULT_PKARR_SETTINGS,
+  formatRelayInput,
+  parseRelayInput,
+} from "@/lib/pkarr-settings"
+import { RESOLVE_POLICY_LABELS, type ResolvePolicyName } from "@/lib/resolve-policy"
+import { usePkarr } from "@/providers/pkarr-provider"
+import { cn } from "@/lib/utils"
+
+const POLICY_OPTIONS: Array<{
+  value: ResolvePolicyName
+  label: string
+  description: string
+}> = [
+  {
+    value: "cache-first",
+    label: RESOLVE_POLICY_LABELS["cache-first"],
+    description: "Use fresh cached data. If unavailable, query the network.",
+  },
+  {
+    value: "network-only",
+    label: RESOLVE_POLICY_LABELS["network-only"],
+    description: "Bypass cached data and request the most recent packet from the DHT.",
+  },
+  {
+    value: "cache-only",
+    label: RESOLVE_POLICY_LABELS["cache-only"],
+    description: "Use cached packets only. Data may be outdated.",
+  },
+]
+
+export function PkarrSettingsDialog() {
+  const { settings, environmentRelays, applySettings, resetSettings } = usePkarr()
+  const [open, setOpen] = useState(false)
+  const [resolvePolicy, setResolvePolicy] = useState(settings.resolvePolicy)
+  const [relayInput, setRelayInput] = useState(formatRelayInput(settings.relays))
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (nextOpen) {
+      setResolvePolicy(settings.resolvePolicy)
+      setRelayInput(formatRelayInput(settings.relays))
+      setValidationError(null)
+    }
+  }
+
+  const handleApply = (event: React.FormEvent) => {
+    event.preventDefault()
+
+    try {
+      const relays = parseRelayInput(relayInput)
+      applySettings({ resolvePolicy, relays })
+      setOpen(false)
+    } catch (cause) {
+      setValidationError(cause instanceof Error ? cause.message : "Invalid relay URL")
+    }
+  }
+
+  const handleReset = () => {
+    resetSettings()
+    setResolvePolicy(DEFAULT_PKARR_SETTINGS.resolvePolicy)
+    setRelayInput("")
+    setValidationError(null)
+    setOpen(false)
+  }
+
+  const fallbackDescription = environmentRelays.length
+    ? `Application default: ${environmentRelays.join(", ")}`
+    : "Empty uses the default relays provided by pkarr."
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="text-muted-foreground hover:text-[#7c63ff]">
+          <Cog className="size-5" />
+          <span className="sr-only">Pkarr settings</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Resolution settings</DialogTitle>
+          <DialogDescription>
+            Choose how records are resolved and which relays this browser uses.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-6" onSubmit={handleApply}>
+          <fieldset className="space-y-3">
+            <legend className="text-sm font-medium text-white">Resolve policy</legend>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {POLICY_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className={cn(
+                    "cursor-pointer rounded-lg border p-3 transition-colors",
+                    resolvePolicy === option.value
+                      ? "border-[#5b40ea] bg-[#5b40ea]/15"
+                      : "border-white/10 bg-white/[0.025] hover:border-white/20"
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="resolve-policy"
+                    value={option.value}
+                    checked={resolvePolicy === option.value}
+                    onChange={() => setResolvePolicy(option.value)}
+                    className="sr-only"
+                  />
+                  <span className="block text-sm font-medium text-white">{option.label}</span>
+                  <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">
+                    {option.description}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="space-y-2">
+            <label htmlFor="pkarr-relays" className="text-sm font-medium text-white">
+              Relay URLs
+            </label>
+            <textarea
+              id="pkarr-relays"
+              value={relayInput}
+              onChange={(event) => {
+                setRelayInput(event.target.value)
+                setValidationError(null)
+              }}
+              rows={4}
+              placeholder="https://pkarr.pubky.app/"
+              aria-invalid={Boolean(validationError)}
+              aria-describedby="pkarr-relay-help pkarr-relay-error"
+              className="flex w-full resize-y rounded-md border border-input bg-[#0f0f10] px-3 py-2 font-mono text-sm outline-none placeholder:text-muted-foreground focus-visible:border-[#5b40ea] focus-visible:ring-2 focus-visible:ring-[#5b40ea]/40 aria-invalid:border-red-400"
+            />
+            <p id="pkarr-relay-help" className="text-xs leading-relaxed text-muted-foreground">
+              One HTTP or HTTPS URL per line, or comma-separated. {fallbackDescription}
+            </p>
+            {validationError && (
+              <p id="pkarr-relay-error" className="text-xs text-red-400">
+                {validationError}
+              </p>
+            )}
+            {relayInput.includes("http://") && (
+              <p className="text-xs text-amber-400/90">
+                Browsers may block HTTP relays when this site is served over HTTPS.
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col-reverse gap-3 border-t border-white/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
+            <Button type="button" variant="ghost" onClick={handleReset} className="text-muted-foreground">
+              <RotateCcw className="size-4" />
+              Reset defaults
+            </Button>
+            <div className="flex gap-2">
+              <DialogClose asChild>
+                <Button type="button" variant="outline">Cancel</Button>
+              </DialogClose>
+              <Button type="submit" className="bg-[#5b40ea] text-white hover:bg-[#4f37cc]">
+                Apply settings
+              </Button>
+            </div>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,5 +1,6 @@
 import { Fingerprint, Github } from "lucide-react"
 import Link from "next/link"
+import { PkarrSettingsDialog } from "@/components/pkarr-settings-dialog"
 
 export function SiteHeader() {
   return (
@@ -13,10 +14,7 @@ export function SiteHeader() {
         </Link>
       </div>
       <div className="flex items-center space-x-4">
-        {/* <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-purple-500 group">
-          <Cog className="w-5 h-5" />
-        </Button>
-        <ThemeToggle /> */}
+        <PkarrSettingsDialog />
         <Link
           href="https://github.com/pubky/pkdns-digger"
           target="_blank"
@@ -29,4 +27,4 @@ export function SiteHeader() {
       </div>
     </header>
   )
-} 
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogClose = DialogPrimitive.Close
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/75 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Content
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl border border-white/10 bg-[#161617] p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-muted-foreground transition-colors hover:text-white focus-visible:ring-2 focus-visible:ring-[#5b40ea]">
+          <X className="size-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("space-y-2", className)} {...props} />
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn("text-xl font-semibold tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn("text-sm leading-relaxed text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/lib/pkarr-settings.ts
+++ b/src/lib/pkarr-settings.ts
@@ -1,0 +1,85 @@
+import { RESOLVE_POLICY_NAMES, type ResolvePolicyName } from "@/lib/resolve-policy"
+
+const SETTINGS_STORAGE_KEY = "pkarr-settings-v1"
+
+export interface PkarrSettings {
+  resolvePolicy: ResolvePolicyName
+  relays: string[]
+}
+
+export const DEFAULT_PKARR_SETTINGS: PkarrSettings = {
+  resolvePolicy: "cache-first",
+  relays: [],
+}
+
+export function loadPkarrSettings(): PkarrSettings {
+  if (typeof window === "undefined") return { ...DEFAULT_PKARR_SETTINGS }
+
+  try {
+    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY)
+    if (!stored) return { ...DEFAULT_PKARR_SETTINGS }
+
+    const settings = JSON.parse(stored) as Partial<PkarrSettings>
+    if (!isResolvePolicyName(settings.resolvePolicy) || !Array.isArray(settings.relays)) {
+      return { ...DEFAULT_PKARR_SETTINGS }
+    }
+
+    return {
+      resolvePolicy: settings.resolvePolicy,
+      relays: parseRelayInput(
+        settings.relays.filter((relay): relay is string => typeof relay === "string").join("\n")
+      ),
+    }
+  } catch {
+    return { ...DEFAULT_PKARR_SETTINGS }
+  }
+}
+
+export function savePkarrSettings(settings: PkarrSettings): void {
+  localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+}
+
+export function clearPkarrSettings(): void {
+  localStorage.removeItem(SETTINGS_STORAGE_KEY)
+}
+
+export function parseRelayInput(input: string): string[] {
+  const relays = input
+    .split(/[\n,]/)
+    .map((relay) => relay.trim())
+    .filter(Boolean)
+    .map(normalizeRelayUrl)
+
+  return Array.from(new Set(relays))
+}
+
+export function formatRelayInput(relays: string[]): string {
+  return relays.join("\n")
+}
+
+export function environmentRelays(): string[] {
+  return process.env.NEXT_PUBLIC_PKARR_RELAYS
+    ?.split(",")
+    .map((relay) => relay.trim())
+    .filter(Boolean) ?? []
+}
+
+function isResolvePolicyName(value: unknown): value is ResolvePolicyName {
+  return RESOLVE_POLICY_NAMES.includes(value as ResolvePolicyName)
+}
+
+function normalizeRelayUrl(relay: string): string {
+  let url: URL
+
+  try {
+    url = new URL(relay)
+  } catch {
+    throw new Error(`Invalid relay URL: ${relay}`)
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Relay URL must use HTTP or HTTPS: ${relay}`)
+  }
+
+  return url.toString()
+}

--- a/src/lib/resolve-policy.ts
+++ b/src/lib/resolve-policy.ts
@@ -1,0 +1,13 @@
+export const RESOLVE_POLICY_NAMES = [
+  "cache-first",
+  "network-only",
+  "cache-only",
+] as const
+
+export type ResolvePolicyName = (typeof RESOLVE_POLICY_NAMES)[number]
+
+export const RESOLVE_POLICY_LABELS: Record<ResolvePolicyName, string> = {
+  "cache-first": "Cache First",
+  "network-only": "Network Only",
+  "cache-only": "Cache Only",
+}

--- a/src/providers/pkarr-provider.tsx
+++ b/src/providers/pkarr-provider.tsx
@@ -1,164 +1,171 @@
 "use client"
 
-/**
- * PkarrProvider: React Context provider that manages a singleton Pkarr Client instance.
- * Handles client initialization, loading states, error handling, and retry logic.
- */
-
-import { Client } from '@synonymdev/pkarr'
-import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
-
+import { Client, ResolvePolicy, type SignedPacket } from "@synonymdev/pkarr"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+import {
+  clearPkarrSettings,
+  DEFAULT_PKARR_SETTINGS,
+  environmentRelays,
+  loadPkarrSettings,
+  savePkarrSettings,
+  type PkarrSettings,
+} from "@/lib/pkarr-settings"
+import type { ResolvePolicyName } from "@/lib/resolve-policy"
 
 interface PkarrContextType {
-  client: Client | null
+  settings: PkarrSettings
+  environmentRelays: string[]
   isLoading: boolean
   error: string | null
+  resolve: (publicKey: string) => Promise<SignedPacket | null>
+  applySettings: (settings: PkarrSettings) => void
+  resetSettings: () => void
   retry: () => void
 }
 
-interface PkarrProviderProps {
-  children: ReactNode
+interface ManagedClient {
+  client: Client
+  pendingRequests: number
+  retired: boolean
+  freed: boolean
 }
 
-// Constants
-const ERRORS = {
-  INITIALIZATION_FAILED: 'Pkarr client failed to initialize. Please refresh the page.',
-  GENERIC: 'Failed to initialize pkarr client'
-} as const
-
-// Singleton state outside React
-interface SingletonState {
-  client: Client | null
-  initializationFailed: boolean
-  initializationPromise: Promise<Client> | null
-}
-
-const singletonState: SingletonState = {
-  client: null,
-  initializationFailed: false,
-  initializationPromise: null
-}
-
-// Context
+const INITIALIZATION_ERROR = "Pkarr client failed to initialize. Please check your relay settings."
 const PkarrContext = createContext<PkarrContextType | undefined>(undefined)
 
-// Helper functions
-const isServerSide = () => typeof window === 'undefined'
-
-const configuredRelays = (): string[] | null => {
-  const relays = process.env.NEXT_PUBLIC_PKARR_RELAYS
-    ?.split(',')
-    .map((relay) => relay.trim())
-    .filter(Boolean)
-
-  return relays?.length ? relays : null
-}
-
-const resetSingletonState = (): void => {
-  singletonState.client = null
-  singletonState.initializationFailed = false
-  // Avoids race condition
-  singletonState.initializationPromise = null
-}
-
-const initializePkarrClient = async (): Promise<Client> => {
-  // Return existing client
-  if (singletonState.client) {
-    return singletonState.client
-  }
-
-  // Don't retry if initialization already failed
-  if (singletonState.initializationFailed) {
-    throw new Error(ERRORS.INITIALIZATION_FAILED)
-  }
-
-  // Don't load on server side
-  if (isServerSide()) {
-    throw new Error('Server-side initialization not supported')
-  }
-
-  // Return existing promise if initialization is in progress
-  if (singletonState.initializationPromise) {
-    return await singletonState.initializationPromise
-  }
-
-  // Start new initialization
-  singletonState.initializationPromise = Promise.resolve().then(() => {
-    try {
-      const relays = configuredRelays()
-      const client = relays ? new Client(relays) : new Client()
-      singletonState.client = client
-      return client
-    } catch (error) {
-      singletonState.initializationFailed = true
-      console.error('Failed to create pkarr client:', error)
-      throw error
-    } finally {
-      singletonState.initializationPromise = null
-    }
-  })
-
-  return await singletonState.initializationPromise
-}
-
-// Provider Component
-export function PkarrProvider({ children }: PkarrProviderProps) {
-  const [client, setClient] = useState<Client | null>(singletonState.client)
+export function PkarrProvider({ children }: { children: ReactNode }) {
+  const configuredEnvironmentRelays = useMemo(environmentRelays, [])
+  const [settings, setSettings] = useState<PkarrSettings>(DEFAULT_PKARR_SETTINGS)
+  const [managedClient, setManagedClient] = useState<ManagedClient | null>(null)
+  const [isHydrated, setIsHydrated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [retryCount, setRetryCount] = useState(0)
+  const clientRef = useRef<ManagedClient | null>(null)
 
-  const handleInitialization = useCallback(async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      
-      // Load client
-      const clientInstance = await initializePkarrClient()
-      
-      setClient(clientInstance)
-      
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : ERRORS.GENERIC
-      setError(errorMessage)
-      console.error('Pkarr client initialization failed:', err)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
-
-  const retry = useCallback(() => {
-    resetSingletonState()
-    handleInitialization()
-  }, [handleInitialization])
+  const effectiveRelays = settings.relays.length
+    ? settings.relays
+    : configuredEnvironmentRelays
+  const relayKey = effectiveRelays.join("\n")
 
   useEffect(() => {
-    handleInitialization()
-  }, [handleInitialization])
+    setSettings(loadPkarrSettings())
+    setIsHydrated(true)
+  }, [])
 
-  const contextValue: PkarrContextType = {
-    client,
+  useEffect(() => {
+    if (!isHydrated) return
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const client = effectiveRelays.length ? new Client(effectiveRelays) : new Client()
+      const nextClient: ManagedClient = {
+        client,
+        pendingRequests: 0,
+        retired: false,
+        freed: false,
+      }
+      const previousClient = clientRef.current
+
+      clientRef.current = nextClient
+      setManagedClient(nextClient)
+      retireClient(previousClient)
+      setIsLoading(false)
+    } catch (cause) {
+      console.error("Failed to create pkarr client:", cause)
+      setManagedClient(null)
+      clientRef.current = null
+      setError(cause instanceof Error ? cause.message : INITIALIZATION_ERROR)
+      setIsLoading(false)
+    }
+
+    return () => {
+      const client = clientRef.current
+      if (client) {
+        retireClient(client)
+        if (clientRef.current === client) clientRef.current = null
+      }
+    }
+    // relayKey intentionally represents the normalized relay configuration.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated, relayKey, retryCount])
+
+  const resolve = useCallback(async (publicKey: string): Promise<SignedPacket | null> => {
+    if (!managedClient) throw new Error(INITIALIZATION_ERROR)
+
+    managedClient.pendingRequests += 1
+    try {
+      return await managedClient.client.resolve(publicKey, toResolvePolicy(settings.resolvePolicy))
+    } finally {
+      managedClient.pendingRequests -= 1
+      freeRetiredClient(managedClient)
+    }
+  }, [managedClient, settings.resolvePolicy])
+
+  const applySettings = useCallback((nextSettings: PkarrSettings) => {
+    const settingsCopy = { ...nextSettings, relays: [...nextSettings.relays] }
+    savePkarrSettings(settingsCopy)
+    setSettings(settingsCopy)
+  }, [])
+
+  const resetSettings = useCallback(() => {
+    clearPkarrSettings()
+    setSettings({ ...DEFAULT_PKARR_SETTINGS })
+  }, [])
+
+  const retry = useCallback(() => setRetryCount((count) => count + 1), [])
+
+  const value: PkarrContextType = {
+    settings,
+    environmentRelays: configuredEnvironmentRelays,
     isLoading,
     error,
-    retry
+    resolve,
+    applySettings,
+    resetSettings,
+    retry,
   }
 
-  return (
-    <PkarrContext.Provider value={contextValue}>
-      {children}
-    </PkarrContext.Provider>
-  )
+  return <PkarrContext.Provider value={value}>{children}</PkarrContext.Provider>
 }
 
-// Hook
 export function usePkarr(): PkarrContextType {
   const context = useContext(PkarrContext)
-  if (context === undefined) {
-    throw new Error('usePkarr must be used within a PkarrProvider')
-  }
+  if (!context) throw new Error("usePkarr must be used within a PkarrProvider")
   return context
 }
 
-// Export for non-React usage
-export async function getPkarrClient(): Promise<Client> {
-  return await initializePkarrClient()
-} 
+function retireClient(managedClient: ManagedClient | null): void {
+  if (!managedClient) return
+  managedClient.retired = true
+  freeRetiredClient(managedClient)
+}
+
+function freeRetiredClient(managedClient: ManagedClient): void {
+  if (managedClient.retired && managedClient.pendingRequests === 0 && !managedClient.freed) {
+    managedClient.freed = true
+    managedClient.client.free()
+  }
+}
+
+function toResolvePolicy(policy: ResolvePolicyName): ResolvePolicy {
+  switch (policy) {
+    case "cache-only":
+      return ResolvePolicy.CacheOnly
+    case "network-only":
+      return ResolvePolicy.NetworkOnly
+    case "cache-first":
+      return ResolvePolicy.CacheFirst
+  }
+}


### PR DESCRIPTION
Updates the digger to benefit from the new features from pkarr v1. In more detail:

- Upgrade @synonymdev/pkarr to 1.0.0.
- Add persisted settings for resolve policy and custom relay URLs.
- Re-resolve automatically when settings change.
- Display the policy used in resolved packet metadata.

### UI Changes

1. Adds a settings button to the top right.
2. Shows with which ResolvePolicy the packet has been fetched.

<img width="1518" height="1190" alt="CleanShot 2026-07-22 at 11 12 32@2x" src="https://github.com/user-attachments/assets/63584bca-a556-40f9-843a-46e0c3cba495" />

In the settings
- You can change the resolve policy which is then stored in the local storage.
- You can also set custom relays which are stored in the local storage as well.

<img width="1270" height="1164" alt="CleanShot 2026-07-22 at 11 14 11@2x" src="https://github.com/user-attachments/assets/9f3ed81e-81dc-439d-8fa2-f8bc68926cae" />
